### PR TITLE
fix allowedDates is undefined

### DIFF
--- a/src/DateRange.vue
+++ b/src/DateRange.vue
@@ -29,7 +29,6 @@
           readonly
         />
         <v-date-picker
-          :allowed-dates="allowedDates"
           :next-icon="nextIcon"
           :prev-icon="prevIcon"
           :dark="dark"


### PR DESCRIPTION
allowedDates is referenced in the date picker properties, but it is undefined. This results in runtime error posted to the console. Remove this line.